### PR TITLE
feat: 探索頁串接後端 API,移除首頁假資料

### DIFF
--- a/src/api/project.js
+++ b/src/api/project.js
@@ -29,3 +29,30 @@ export const createProjectPlan = (projectId, data, token) => {
 export const getProjectById = (projectId) => {
   return axios.get(`${BASE_URL}/api/v1/projects/${projectId}`)
 }
+
+// 取得首頁整包分類
+export const getAllProjects = ({
+  page = 1,
+  per_page = 6,
+  filter = 'all',
+  sort = 'newest',
+  category_id = null,
+} = {}) => {
+  const params = {
+    page,
+    per_page,
+    filter,
+    sort,
+  }
+
+  if (category_id) {
+    params.category_id = category_id
+  }
+
+  return axios.get(`${BASE_URL}/api/v1/projects`, { params })
+}
+
+// 取得所有分類（探索頁用）
+export const getAllCategories = () => {
+  return axios.get(`${BASE_URL}/api/v1/projects/categories`)
+}

--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="card shadow-sm rounded-5 d-flex flex-column overflow-hidden">
+    <!-- 封面 + 標籤 + 收藏 -->
+    <div class="position-relative">
+      <img :src="project.cover" class="card-img-top" :alt="project.title" />
+      <img :src="project.category_img || '/default.png'" alt="分類標籤" class="category-badge" />
+      <div class="favorite-wrapper">
+        <img src="/favorite.png" alt="收藏" class="favorite-icon" />
+      </div>
+    </div>
+
+    <!-- 內容 -->
+    <div class="card-body text-start px-3 pb-4 d-flex flex-column flex-grow-1">
+      <h5 class="card-title fw-bold text-ellipsis-2">{{ project.title }}</h5>
+      <p class="card-text small mb-1 text-ellipsis-3">{{ project.summary }}</p>
+      <p class="text-proposer mb-2">提案單位：{{ project.proposer }}</p>
+
+      <div class="mt-auto">
+        <div class="d-flex justify-content-between align-items-center">
+          <small class="text-muted">
+            {{ project.days_left === 0 ? '已結束' : `倒數 ${project.days_left} 天` }}
+          </small>
+          <small>{{ project.percentage }}%</small>
+        </div>
+        <div class="progress my-2 progress-custom">
+          <div class="progress-bar" :style="{ width: project.percentage + '%' }"></div>
+        </div>
+        <div class="d-flex justify-content-between align-items-center">
+          <strong>NT$ {{ project.amount.toLocaleString() }}</strong>
+          <button class="btn btn-sm btn-danger rounded-pill px-3">立即贊助 ></button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  project: {
+    type: Object,
+    required: true,
+  },
+})
+</script>
+
+<style scoped>
+.card {
+  width: 100%;
+  max-width: 320px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-img-top {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  display: block;
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.category-badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: 60px;
+  z-index: 2;
+}
+
+.favorite-wrapper {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 36px;
+  height: 36px;
+  background-color: rgba(26, 26, 26, 0.2);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  cursor: pointer;
+}
+.favorite-icon {
+  width: 18px;
+  height: 18px;
+  filter: brightness(0) invert(1);
+}
+
+.text-ellipsis-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.5em;
+  min-height: 3em;
+}
+.text-ellipsis-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.5em;
+  min-height: 4.5em;
+}
+
+.text-proposer {
+  color: #c4c4c4;
+  font-size: 14px;
+}
+
+.progress-custom {
+  height: 6px;
+  background-color: #f3f3f3;
+  border-radius: 100px;
+  overflow: hidden;
+}
+.progress-custom .progress-bar {
+  background-image: linear-gradient(to right, #fc7c9d, #ffc443);
+}
+</style>

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -35,7 +35,7 @@
             />
           </div>
         </form>
-        <a href="#" class="nav-link text-dark">探索</a>
+        <router-link to="/projects/explore-projects" class="nav-link text-dark">探索</router-link>
         <router-link to="/projects/create" class="nav-link text-dark">提案</router-link>
       </div>
 

--- a/src/layouts/Section2.vue
+++ b/src/layouts/Section2.vue
@@ -4,93 +4,102 @@
     <img src="/homepageS2-bg.png" alt="bg1" class="section2-bg1" />
     <img src="/homepageS2-bg2.png" alt="bg2" class="section2-bg2" />
     <img src="/homepageS2-illustration.png" alt="illustration" class="section2-illustration" />
+    <div v-if="isLoading">載入中...</div>
+    <div v-else>
+      <h2 class="section-title text-danger fs-4 fw-bold mb-5">募資中</h2>
 
-    <h2 class="section-title text-danger fs-4 fw-bold mb-5">募資中</h2>
-    <div class="container" style="padding-left: 10rem; padding-right: 10rem;">
-      <div class="row justify-content-center g-4">
-        <div class="col-md-4" v-for="(card, index) in cards" :key="index">
-          <div class="card shadow-sm rounded-5 h-100 d-flex flex-column overflow-hidden">
-            <!-- 卡片圖片與 icon -->
-            <div class="position-relative">
-              <img :src="card.image" class="card-img-top rounded-top-4" :alt="card.title" />
-              <img :src="card.categoryImg" alt="分類標籤" class="category-badge" />
-              <div class="favorite-wrapper">
-                <img src="/favorite.png" alt="收藏" class="favorite-icon" />
+      <div class="container" style="padding-left: 10rem; padding-right: 10rem">
+        <div class="row justify-content-center g-4">
+          <div class="col-md-4" v-for="(card, index) in visibleCards" :key="index">
+            <div class="card shadow-sm rounded-5 h-100 d-flex flex-column overflow-hidden">
+              <!-- 卡片圖片與 icon -->
+              <div class="position-relative">
+                <img :src="card.cover" class="card-img-top rounded-top-4" :alt="card.title" />
+                <img
+                  :src="card.category_img || '/default.png'"
+                  alt="分類標籤"
+                  class="category-badge"
+                />
+                <div class="favorite-wrapper">
+                  <img src="/favorite.png" alt="收藏" class="favorite-icon" />
+                </div>
               </div>
-            </div>
 
-            <!-- 卡片內文 -->
-            <div class="card-body text-start px-3 pb-4 d-flex flex-column flex-grow-1">
-              <!-- 標題區 -->
-              <h5 class="card-title fw-bold text-ellipsis-2">{{ card.title }}</h5>
+              <!-- 卡片內文 -->
+              <div class="card-body text-start px-3 pb-4 d-flex flex-column flex-grow-1">
+                <!-- 標題區 -->
+                <h5 class="card-title fw-bold text-ellipsis-2">{{ card.title }}</h5>
+                <!-- 說明區 -->
+                <p class="card-text small mb-1 text-ellipsis-3">{{ card.summary }}</p>
+                <!-- 提案單位 -->
+                <p class="text-proposer mb-2">提案單位：{{ card.proposer }}</p>
 
-              <!-- 說明區 -->
-              <p class="card-text small mb-1 text-ellipsis-3">{{ card.description }}</p>
-
-              <!-- 提案單位 -->
-              <p class="text-proposer mb-2">提案單位：{{ card.proposer }}</p>
-
-              <!-- 進度與按鈕（固定底部） -->
-              <div class="mt-auto">
-                <div class="d-flex justify-content-between align-items-center">
-                  <small class="text-muted">倒數 {{ card.daysLeft }} 天</small>
-                  <small>{{ card.progress }}%</small>
-                </div>
-                <div class="progress my-2 progress-custom">
-                  <div class="progress-bar" :style="{ width: card.progress + '%' }"></div>
-                </div>
-                <div class="d-flex justify-content-between align-items-center">
-                  <strong>NT$ {{ card.amount.toLocaleString() }}</strong>
-                  <button class="btn btn-sm btn-danger rounded-pill px-3">立即贊助 ></button>
+                <!-- 進度與按鈕（固定底部） -->
+                <div class="mt-auto">
+                  <div class="d-flex justify-content-between align-items-center">
+                    <small class="text-muted">倒數 {{ card.days_left }} 天</small>
+                    <small>{{ card.percentage }}%</small>
+                  </div>
+                  <div class="progress my-2 progress-custom">
+                    <div class="progress-bar" :style="{ width: card.percentage + '%' }"></div>
+                  </div>
+                  <div class="d-flex justify-content-between align-items-center">
+                    <strong>NT$ {{ card.amount.toLocaleString() }}</strong>
+                    <button class="btn btn-sm btn-danger rounded-pill px-3">立即贊助 ></button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
+
+        <button
+          class="btn btn-outline-danger rounded-pill mt-4"
+          @click="showAll = !showAll"
+          v-if="projects.length > 3"
+        >
+          {{ showAll ? '收起' : '查看更多' }}
+        </button>
       </div>
-      <button class="btn btn-outline-danger rounded-pill mt-4">查看更多</button>
     </div>
   </section>
 </template>
 
 <script setup>
-const cards = [
-  {
-    title: '弱勢偏鄉與罕病者【復康巴士服務補助】',
-    description: '對許多身障者與罕病者而言，復康巴士的交通費用是一筆沈重負擔。為了不讓距離成為就醫與生活的障礙，協會致力...',
-    proposer: '多扶無障礙生活與交通發展協會',
-    image: '/homepageS2-card01.png',
-    categoryImg: '/category-人文.png',
-    progress: 33,
-    amount: 26580,
-    daysLeft: 25,
-  },
-  {
-    title: '偏鄉醫療支援計畫',
-    description: '偏鄉地區的醫療資源匱乏，許多居民因為交通不便、醫療設施不足，無法及時獲得必要的醫療服務。',
-    proposer: '多偏鄉醫療支援協會',
-    image: '/homepageS2-card02.png',
-    categoryImg: '/category-人文.png',
-    progress: 24,
-    amount: 9456,
-    daysLeft: 34,
-  },
-  {
-    title: '海洋廢棄物清理計畫',
-    description: '如果我們不採取行動，未來的海洋將不再是生命的搖籃，而是廢棄物的墳場。',
-    proposer: '海洋守護者聯盟',
-    image: '/homepageS2-card03.png',
-    categoryImg: '/category-環境.png',
-    progress: 24,
-    amount: 26000,
-    daysLeft: 15,
-  },
-];
+import { ref, computed, onMounted } from 'vue'
+import { getAllProjects } from '@/api/project'
+import axios from 'axios'
+
+const isLoading = ref(true)
+const projects = ref([])
+const showAll = ref(false)
+
+onMounted(async () => {
+  try {
+    const res = await getAllProjects({
+      filter: 'funding',
+      page: 1,
+      per_page: 6,
+    })
+
+    console.log('API 回傳：', res.data)
+
+    if (res.data.status && Array.isArray(res.data.data)) {
+      projects.value = res.data.data
+    }
+  } catch (err) {
+    console.error('取得募資中失敗:', err)
+  } finally {
+    isLoading.value = false
+  }
+})
+
+const visibleCards = computed(() => (showAll.value ? projects.value : projects.value.slice(0, 3)))
 </script>
 
 <style scoped>
 .funding-section {
-  background: linear-gradient(to right, #FFEDF2, #FFF6E3);
+  background: linear-gradient(to right, #ffedf2, #fff6e3);
   position: relative;
   padding-top: 8rem;
   padding-bottom: 8rem;
@@ -132,7 +141,7 @@ const cards = [
 }
 
 .text-proposer {
-  color: #C4C4C4;
+  color: #c4c4c4;
   font-size: 14px;
 }
 
@@ -143,7 +152,7 @@ const cards = [
   overflow: hidden;
 }
 .progress-custom .progress-bar {
-  background-image: linear-gradient(to right, #FC7C9D, #FFC443);
+  background-image: linear-gradient(to right, #fc7c9d, #ffc443);
 }
 
 /* 標題區兩行 */

--- a/src/layouts/Section3.vue
+++ b/src/layouts/Section3.vue
@@ -5,92 +5,115 @@
     <img src="/homepageS3-bg2.png" alt="bg2" class="section3-bg2" />
     <img src="/homepageS3-illustration.png" alt="illustration" class="section3-illustration" />
 
-    <h2 class="section-title text-danger fs-4 fw-bold mb-5">長期贊助</h2>
-    <div class="container" style="padding-left: 10rem; padding-right: 10rem;">
-      <div class="row justify-content-center g-4">
-        <div class="col-md-4" v-for="(card, index) in cards" :key="index">
-          <div class="card shadow-sm rounded-5 h-100 d-flex flex-column overflow-hidden">
-            <!-- 卡片圖片與 icon -->
-            <div class="position-relative">
-              <img :src="card.image" class="card-img-top rounded-top-4" :alt="card.title" />
-              <img :src="card.categoryImg" alt="分類標籤" class="category-badge" />
-              <div class="favorite-wrapper">
-                <img src="/favorite.png" alt="收藏" class="favorite-icon" />
+    <div v-if="isLoading">載入中...</div>
+    <div v-else>
+      <h2 class="section-title text-danger fs-4 fw-bold mb-5">長期贊助</h2>
+
+      <div
+        v-if="!isLoading && visibleCards.length > 0"
+        class="container"
+        style="padding-left: 10rem; padding-right: 10rem"
+      >
+        <div class="row justify-content-center g-4">
+          <div class="col-md-4" v-for="(card, index) in visibleCards" :key="index">
+            <div class="card shadow-sm rounded-5 h-100 d-flex flex-column overflow-hidden">
+              <!-- 卡片圖片與 icon -->
+              <div class="position-relative">
+                <img :src="card.cover" class="card-img-top rounded-top-4" :alt="card.title" />
+                <img
+                  :src="card.category_img || '/default.png'"
+                  alt="分類標籤"
+                  class="category-badge"
+                />
+                <div class="favorite-wrapper">
+                  <img src="/favorite.png" alt="收藏" class="favorite-icon" />
+                </div>
               </div>
-            </div>
 
-            <!-- 卡片內文 -->
-            <div class="card-body text-start px-3 pb-4 d-flex flex-column flex-grow-1">
-              <!-- 標題區 -->
-              <h5 class="card-title fw-bold text-ellipsis-2">{{ card.title }}</h5>
+              <!-- 卡片內文 -->
+              <div class="card-body text-start px-3 pb-4 d-flex flex-column flex-grow-1">
+                <!-- 標題區 -->
+                <h5 class="card-title fw-bold text-ellipsis-2">{{ card.title }}</h5>
+                <!-- 說明區 -->
+                <p class="card-text small mb-1 text-ellipsis-3">{{ card.summary }}</p>
+                <!-- 提案單位 -->
+                <p class="text-proposer mb-2">提案單位：{{ card.proposer }}</p>
 
-              <!-- 說明區 -->
-              <p class="card-text small mb-1 text-ellipsis-3">{{ card.description }}</p>
-
-              <!-- 提案單位 -->
-              <p class="text-proposer mb-2">提案單位：{{ card.proposer }}</p>
-
-              <!-- 進度與按鈕（固定底部） -->
-              <div class="mt-auto">
-                <div class="d-flex justify-content-between align-items-center">
-                  <small class="text-muted">倒數 {{ card.daysLeft }} 天</small>
-                  <small>{{ card.progress }}%</small>
-                </div>
-                <div class="progress my-2 progress-custom">
-                  <div class="progress-bar" :style="{ width: card.progress + '%' }"></div>
-                </div>
-                <div class="d-flex justify-content-between align-items-center">
-                  <strong>NT$ {{ card.amount.toLocaleString() }}</strong>
-                  <button class="btn btn-sm btn-danger rounded-pill px-3">立即贊助 ></button>
+                <!-- 進度與按鈕（固定底部） -->
+                <div class="mt-auto">
+                  <div class="d-flex justify-content-between align-items-center">
+                    <small class="text-muted">倒數 {{ card.daysLeft }} 天</small>
+                    <small>{{ card.percentage }}%</small>
+                  </div>
+                  <div class="progress my-2 progress-custom">
+                    <div class="progress-bar" :style="{ width: card.percentage + '%' }"></div>
+                  </div>
+                  <div class="d-flex justify-content-between align-items-center">
+                    <strong>NT$ {{ card.amount.toLocaleString() }}</strong>
+                    <button class="btn btn-sm btn-danger rounded-pill px-3">立即贊助 ></button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-      <button class="btn btn-outline-danger rounded-pill mt-4">查看更多</button>
+
+      <!-- 查看更多 -->
+      <div class="text-center mt-4" v-if="longTermProjects.length > 3">
+        <button class="btn btn-outline-danger rounded-pill mt-4" @click="showAll = !showAll">
+          {{ showAll ? '收起' : '查看更多' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- 沒資料時 -->
+    <div v-if="!isLoading && visibleCards.length === 0" class="text-muted my-5">
+      (尚無長期贊助資料)
     </div>
   </section>
 </template>
 
 <script setup>
-const cards = [
-  {
-    title: '讓偏鄉沒有遺憾',
-    description: '在這個世界上，仍許多偏鄉孩子因為資源不足錯過了學習、夢想和成長的機會。',
-    proposer: '無憾未來兒童教育基金',
-    image: '/homepageS3-card01.png',
-    categoryImg: '/category-人文.png',
-    progress: 60,
-    amount: 100000,
-    daysLeft: 9999,
-  },
-  {
-    title: '讓每一頓飯都充滿溫暖',
-    description: '對我們來說，一日三餐是理所當然的日常，但對許多弱勢家庭來說，每一餐都是沈重的負擔。',
-    proposer: '溫暖一餐關懷協會',
-    image: '/homepageS3-card02.png',
-    categoryImg: '/category-人文.png',
-    progress: 60,
-    amount: 128900,
-    daysLeft: 9999,
-  },
-  {
-    title: '動物救傷站計畫',
-    description: '在城市的街頭、鄉間的小路，每天都有受傷、生病、無助的動物等待救援。',
-    proposer: '希望毛孩救援站',
-    image: '/homepageS3-card03.png',
-    categoryImg: '/category-動物.png',
-    progress: 60,
-    amount: 40000,
-    daysLeft: 9999,
-  },
-];
+import { ref, computed, onMounted } from 'vue'
+import { getAllProjects } from '@/api/project'
+
+const isLoading = ref(true)
+const longTermProjects = ref([])
+const showAll = ref(false)
+
+onMounted(async () => {
+  try {
+    const params = {
+      page: 1,
+      per_page: 6,
+      filter: 'long',
+      sort: 'newest',
+    }
+
+    const res = await getAllProjects(params)
+    console.log('📦 長期贊助 API 回傳：', res.data)
+
+    if (res.data?.status && Array.isArray(res.data.data)) {
+      longTermProjects.value = res.data.data
+    } else {
+      console.warn('沒有符合條件的長期贊助資料')
+    }
+  } catch (err) {
+    console.error('取得長期贊助資料失敗:', err)
+  } finally {
+    isLoading.value = false
+  }
+})
+
+const visibleCards = computed(() =>
+  showAll.value ? longTermProjects.value : longTermProjects.value.slice(0, 3)
+)
 </script>
 
 <style scoped>
 .funding-section {
-  background: linear-gradient(to right, #FFEDF2, #FFF6E3);
+  background: linear-gradient(to right, #ffedf2, #fff6e3);
   position: relative;
   padding-top: 8rem;
   padding-bottom: 8rem;
@@ -101,6 +124,13 @@ const cards = [
   height: 100%;
   max-width: 300px;
   margin: 0 auto;
+}
+.card-img-top {
+  width: 100%;
+  height: 200px; /* 與原卡片圖片保持一致可調 */
+  object-fit: cover;
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
 }
 
 .category-badge {
@@ -132,7 +162,7 @@ const cards = [
 }
 
 .text-proposer {
-  color: #C4C4C4;
+  color: #c4c4c4;
   font-size: 14px;
 }
 
@@ -143,7 +173,7 @@ const cards = [
   overflow: hidden;
 }
 .progress-custom .progress-bar {
-  background-image: linear-gradient(to right, #FC7C9D, #FFC443);
+  background-image: linear-gradient(to right, #fc7c9d, #ffc443);
 }
 
 /* 標題區兩行 */

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -42,6 +42,29 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/projects/explore-projects',
+      name: 'explore-projects',
+      component: () => import('@/views/projects/ExploreProjects.vue'),
+      // redirect: '/projects/funding',
+      children: [
+        {
+          path: 'funding',
+          name: 'funding-projects',
+          component: () => import('@/views/projects/FundingProjects.vue'),
+        },
+        {
+          path: 'long-term',
+          name: 'long-term-projects',
+          component: () => import('@/views/projects/LongTermProjects.vue'),
+        },
+        {
+          path: 'archived',
+          name: 'archived-projects',
+          component: () => import('@/views/projects/ArchivedProjects.vue'),
+        },
+      ],
+    },
+    {
       path: '/user',
       component: () => import('@/layouts/UserLayout.vue'),
       meta: { requiresAuth: true },

--- a/src/views/RegisterForm.vue
+++ b/src/views/RegisterForm.vue
@@ -49,9 +49,12 @@
                 class="form-control"
                 id="username"
                 v-model="form.username"
+                maxlength="50"
                 placeholder="請輸入使用者名稱"
+                :class="{ 'is-invalid': isUsernameTooLong }"
                 required
               />
+              <div class="invalid-feedback">使用者名稱最多 50 字元</div>
             </div>
 
             <!-- 密碼 -->
@@ -194,6 +197,8 @@ const passwordMismatch = computed(
   () => form.password && form.confirmPassword && form.password !== form.confirmPassword
 )
 
+const isUsernameTooLong = computed(() => form.username.length > 50)
+
 //Modal 控制
 const modalRef = ref(null)
 const modalMessage = ref('')
@@ -213,6 +218,10 @@ function showModal(msg, type = 'danger') {
 async function handleRegister() {
   if (!isEmailValid.value || !isPasswordValid.value || passwordMismatch.value || !form.agree) return
 
+  if (form.username.length > 50) {
+    showModal('使用者名稱長度不能超過 50 字元')
+    return
+  }
   try {
     const payload = {
       account: form.email,
@@ -221,7 +230,7 @@ async function handleRegister() {
     }
     await axios.post(`${baseUrl}/api/v1/users/signup`, payload)
     //modalMessage.value = '註冊成功！即將跳轉登入頁'
-    showModal('註冊成功！', '即將跳轉登入頁')
+    showModal('註冊成功！即將跳轉登入頁', 'success')
     setTimeout(() => {
       modalInstance.hide() //關閉 Modal
       const backdrop = document.querySelector('.modal-backdrop')

--- a/src/views/projects/ArchivedProjects.vue
+++ b/src/views/projects/ArchivedProjects.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="row justify-content-center g-4">
+    <div class="col-md-4" v-for="project in visibleProjects" :key="project.id">
+      <ProjectCard :project="project" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import ProjectCard from '@/components/ProjectCard.vue'
+</script>

--- a/src/views/projects/ExploreProjects.vue
+++ b/src/views/projects/ExploreProjects.vue
@@ -1,0 +1,270 @@
+<template>
+  <section class="explore-page">
+    <!-- 🔹 背景圖與 Banner -->
+    <section class="explore-banner text-center text-white">
+      <div class="banner-text-container">
+        <h2 class="fw-bold text-danger">探索提案</h2>
+        <p class="text-muted">發現更多你關心的議題</p>
+      </div>
+    </section>
+
+    <!--  篩選與搜尋 -->
+    <section class="container my-4">
+      <div class="d-flex justify-content-between flex-wrap align-items-center">
+        <!-- 篩選按鈕 -->
+        <ul class="nav nav-pills gap-4 mb-2">
+          <li class="nav-item" v-for="tag in filters" :key="tag.key">
+            <button
+              class="btn filter-tab"
+              :class="{ active: currentFilter === tag.key }"
+              @click="setFilter(tag.key)"
+            >
+              {{ tag.label }}
+            </button>
+          </li>
+        </ul>
+
+        <!-- 搜尋與分類 -->
+        <div class="tools-wrapper mb-2 d-flex gap-3 align-items-center ms-auto">
+          <div class="search-input">
+            <i class="bi bi-search"></i>
+            <input
+              type="text"
+              placeholder="輸入關鍵字搜尋專案"
+              v-model="searchKeyword"
+              @input="fetchProjects"
+            />
+          </div>
+
+          <div class="category-wrapper">
+            <select
+              class="form-select rounded-pill border-0 category-select"
+              v-model="selectedCategory"
+              @change="fetchProjects"
+            >
+              <option value="">分類</option>
+              <option v-for="cat in categories" :key="cat.id" :value="cat.id">
+                {{ cat.name }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 卡片列表 -->
+    <section class="container">
+      <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+        <div class="col" v-for="project in visibleProjects" :key="project.id">
+          <ProjectCard :project="project" />
+        </div>
+      </div>
+
+      <!-- 分頁 -->
+      <nav class="d-flex justify-content-center mt-4">
+        <ul class="pagination custom-pagination gap-2">
+          <li class="page-item" :class="{ disabled: currentPage === 1 }">
+            <a class="page-link" href="#" @click.prevent="changePage(currentPage - 1)">‹</a>
+          </li>
+          <li
+            class="page-item"
+            v-for="page in totalPages"
+            :key="page"
+            :class="{ active: currentPage === page }"
+          >
+            <a class="page-link" href="#" @click.prevent="changePage(page)">{{ page }}</a>
+          </li>
+          <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+            <a class="page-link" href="#" @click.prevent="changePage(currentPage + 1)">›</a>
+          </li>
+        </ul>
+      </nav>
+    </section>
+  </section>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { getAllProjects, getAllCategories } from '@/api/project'
+import axios from 'axios'
+import ProjectCard from '@/components/ProjectCard.vue'
+
+const filters = [
+  { key: 'all', label: '全部專案' },
+  { key: 'recent', label: '近期專案' },
+  { key: 'popular', label: '熱門專案' },
+  { key: 'long', label: '長期贊助' },
+]
+
+const currentFilter = ref('all')
+const searchKeyword = ref('')
+const selectedCategory = ref('')
+const currentPage = ref(1)
+const perPage = 9
+const projects = ref([])
+const totalPages = ref(1)
+const categories = ref([])
+
+const fetchProjects = async () => {
+  const res = await getAllProjects({
+    filter: currentFilter.value,
+    page: currentPage.value,
+    per_page: perPage,
+    search: searchKeyword.value,
+    category_id: selectedCategory.value,
+  })
+  if (res.data?.status) {
+    projects.value = res.data.data
+    totalPages.value = res.data.pagination.total_pages
+  }
+}
+
+const fetchCategories = async () => {
+  const res = await getAllCategories()
+  if (res.data?.status) {
+    categories.value = res.data.data
+  }
+}
+
+const setFilter = (key) => {
+  currentFilter.value = key
+  currentPage.value = 1
+  fetchProjects()
+}
+
+const changePage = (page) => {
+  if (page >= 1 && page <= totalPages.value) {
+    currentPage.value = page
+    fetchProjects()
+  }
+}
+
+const visibleProjects = computed(() => projects.value)
+
+onMounted(() => {
+  fetchProjects()
+  fetchCategories()
+})
+</script>
+
+<style scoped>
+.explore-page {
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  background-image: url('@/assets/images/explore bg.png'), url('@/assets/images/bg.png');
+  background-repeat: no-repeat, no-repeat;
+  background-size: cover, cover;
+  background-position:
+    top 150px center,
+    top center;
+  background-attachment: scroll, scroll;
+}
+
+.explore-banner {
+  padding-top: 10rem;
+  padding-bottom: 13rem;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  position: relative;
+}
+.banner-text-container {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: left;
+  padding-right: 60rem;
+}
+.container {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-right: 2rem;
+  margin-top: 80px;
+}
+.tools-wrapper {
+  min-width: 420px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+.filter-tab {
+  background: none;
+  border: none;
+  color: #333;
+  position: relative;
+  padding-bottom: 0.25rem;
+  font-size: 24px;
+}
+.filter-tab.active {
+  color: #e74c3c;
+  font-weight: bold;
+}
+.filter-tab.active::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 60%;
+  height: 2px;
+  background-color: #e74c3c;
+  transform: translateX(-50%);
+}
+.form-control {
+  background: transparent;
+}
+.search-input {
+  display: flex;
+  align-items: center;
+  background-color: #f9f9f9;
+  border-radius: 999px;
+  padding: 0 0.75rem;
+  height: 40px;
+  width: 280px;
+  flex-shrink: 0;
+}
+.search-input i {
+  font-size: 18px;
+  color: #333;
+  margin-right: 0.5rem;
+}
+.search-input input {
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 16px;
+  width: 100%;
+}
+.category-select {
+  background-color: #f9f9f9;
+  height: 40px;
+  padding: 0 1rem;
+  font-size: 16px;
+  width: 150px;
+}
+.custom-pagination .page-link {
+  border-radius: 50%;
+  background-color: transparent;
+  border: none;
+  width: 36px;
+  height: 36px;
+  text-align: center;
+  line-height: 36px;
+  color: #333;
+}
+
+.custom-pagination .page-item.active .page-link {
+  background-color: #ff5c5c;
+  color: #fff;
+}
+
+@media (max-width: 767.98px) {
+  .explore-banner {
+    padding-top: 4rem;
+  }
+  .tools-wrapper {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>

--- a/src/views/projects/FundingProjects.vue
+++ b/src/views/projects/FundingProjects.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="row justify-content-center g-4">
+    <div class="col-md-4" v-for="project in visibleProjects" :key="project.id">
+      <ProjectCard :project="project" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import ProjectCard from '@/components/ProjectCard.vue'
+</script>

--- a/src/views/projects/LongTermProjects.vue
+++ b/src/views/projects/LongTermProjects.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="row justify-content-center g-4">
+    <div class="col-md-4" v-for="project in visibleProjects" :key="project.id">
+      <ProjectCard :project="project" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import ProjectCard from '@/components/ProjectCard.vue'
+</script>


### PR DESCRIPTION
## ✨ 變更內容

- 移除首頁的假資料
- 探索頁改為串接 `/api/v1/projects` 後端 API，支援：
  - filter 篩選（全部、近期、熱門、長期）
  - 分類下拉選單（動態取得）
  - 關鍵字搜尋
  - 分頁功能

## 🔍 測試方式

- 在探索頁切換分類、搜尋、分頁，確認資料更新正常
- 檢查無資料時是否顯示提示訊息
- 手機響應式下切換 UI 無異常

## 🧩 影響範圍

- `ExploreView.vue`
- `api/project.js`
- 部分樣式調整於 `ExploreView.vue` scoped style 區塊

## 📝 備註

- 如需測試分類，請後端資料有對應分類資料與圖片
